### PR TITLE
Add option to set valid time of fork resource

### DIFF
--- a/kubeforkctl/cmd/manifest.go
+++ b/kubeforkctl/cmd/manifest.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wantedly/kubefork-controller/kubeforkctl/domain"
@@ -21,6 +22,7 @@ type manifestOption struct {
 	image                string
 	env                  map[string]string
 	forkManagerName      string
+	validTime            int64
 	kubeConfigPath       string
 }
 
@@ -58,6 +60,7 @@ Deployment-duplicator create forked Deployment from DeploymentCopy.
 	cmd.Flags().StringVar(&opt.image, "image", "", "image of forked container\n(support '<name>:<tag>' format)")
 	cmd.Flags().StringToStringVarP(&opt.env, "env", "e", map[string]string{}, "custom env vars for forked containers which ")
 	cmd.Flags().StringVarP(&opt.forkManagerName, "fork-manager", "f", "", "name of fork manager\n(support '<namespace>/<name>' format)")
+	cmd.Flags().Int64VarP(&opt.validTime, "valid-time", "v", 8, "valid time of fork resource (hour)")
 	cmd.Flags().StringVarP(&opt.kubeConfigPath, "kubeconfig", "k", os.Getenv("KUBECONFIG"), "path of kubeconig\n(loading order follows the same rule as kubectl)")
 
 	return cmd
@@ -109,7 +112,7 @@ func (m manifestCmdRunner) manifestRun(cmd *cobra.Command, _ []string) error {
 	}
 	containers := domain.NewContainers(m.option.image, containerNames, env)
 
-	f := domain.NewFork(m.option.identifier, m.option.namespace, m.option.forkManagerName, m.option.replicaNum, serviceSelector, deploymentSelector,
+	f := domain.NewFork(m.option.identifier, m.option.namespace, m.option.forkManagerName, m.option.replicaNum, time.Duration(m.option.validTime), serviceSelector, deploymentSelector,
 		containers, m.option.deploymentAnnotation)
 
 	if err := f.OutputManifest(m.option.outputPath); err != nil {

--- a/kubeforkctl/domain/fork.go
+++ b/kubeforkctl/domain/fork.go
@@ -17,7 +17,7 @@ type Fork struct {
 	f *v1beta1.Fork
 }
 
-func NewFork(identifier, namespace, forkManagerName string, replicaNum int32, serviceSelector, deploymentSelector *metav1.LabelSelector,
+func NewFork(identifier, namespace, forkManagerName string, replicaNum int32, validTime time.Duration, serviceSelector, deploymentSelector *metav1.LabelSelector,
 	containers []v1.Container, deploymentAnnotation map[string]string) Fork {
 	fork := v1beta1.Fork{
 		TypeMeta: metav1.TypeMeta{
@@ -33,7 +33,7 @@ func NewFork(identifier, namespace, forkManagerName string, replicaNum int32, se
 			Manager:    forkManagerName,
 			Identifier: identifier,
 			Deadline: &metav1.Time{
-				Time: time.Now().Add(time.Hour * 1),
+				Time: time.Now().Add(time.Hour * validTime),
 			},
 			Services: &v1beta1.ForkService{
 				Selector: serviceSelector, // this field depends on '--service-label' and '--service-name' options


### PR DESCRIPTION
## Why
resolve #7 


## What
Add option to set valid time of fork resource.
In the future, we would like to be able to set up to minutes and seconds, but for now, only hours can be set.