### PR TITLE
enable generateEmbeddedObjetMeta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/crd/bases/fork.k8s.wantedly.com_forks.yaml
+++ b/config/crd/bases/fork.k8s.wantedly.com_forks.yaml
@@ -99,6 +99,23 @@ spec:
                     properties:
                       metadata:
                         description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
                         type: object
                       spec:
                         description: 'Specification of the desired behavior of the


### PR DESCRIPTION
## Why
Missing `generateEmbedeedObjectMeta=true` caused unintended behavior, such as labels not being overwritten.

Migration error during kubebuilder upgrade.

## What

add `generateEmbedeedObjectMeta=true` on controller-gen